### PR TITLE
Hide lazy loaded images in the mobile site

### DIFF
--- a/native-mathml/data/mediawiki.css
+++ b/native-mathml/data/mediawiki.css
@@ -13,6 +13,10 @@
     height: auto;
     opacity: 1;
 }
+/* Support where MediaWiki lazy loaded images */
+.mwe-math-mathml-inline ~ .lazy-image-placeholder,
+.mwe-math-mathml-display ~ .lazy-image-placeholder,
+/* Support where MediaWiki doesn't lazy load images */
 .mwe-math-mathml-inline + .mwe-math-fallback-image-inline,
 .mwe-math-mathml-display + .mwe-math-fallback-image-display {
     display: none !important;


### PR DESCRIPTION
The mobile site markup slightly differs from the desktop markup in
that it replaces images with a lazy-image-placeholder

Hiding this will not only avoid rendering images twice in the mobile
site but it will also  prevent the loading of these images which will
save lots of bandwidth for users with the Mathzilla extension